### PR TITLE
Release version 2.0

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/FileSystemEventPublisher.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FileSystemEventPublisher.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FileSystemEventPublisher"
+               BuildableName = "FileSystemEventPublisher"
+               BlueprintName = "FileSystemEventPublisher"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FileSystemEventPublisherTests"
+               BuildableName = "FileSystemEventPublisherTests"
+               BlueprintName = "FileSystemEventPublisherTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FileSystemEventPublisherTests"
+               BuildableName = "FileSystemEventPublisherTests"
+               BlueprintName = "FileSystemEventPublisherTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FileSystemEventPublisher"
+            BuildableName = "FileSystemEventPublisher"
+            BlueprintName = "FileSystemEventPublisher"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ A publisher that tracks changes in the file system.
 
 Example usage:
 
+    let tmp = FileManager.default.temporaryDirectory
+    fd = try! FileDescriptor.open(tmp.path, .readOnly, options: .eventOnly)
     let cancellable = DispatchSource.publish(
       .all,
-      for: FileManager.default.temporaryDirectory
+      at: fd
     )
     .receive(on: RunLoop.main)
     .sink { event in

--- a/Sources/FileSystemEventPublisher/FileSystemEventPublisher.swift
+++ b/Sources/FileSystemEventPublisher/FileSystemEventPublisher.swift
@@ -71,11 +71,11 @@ private extension DispatchSource {
 
 @available(macOS 11.0, *, iOS 14.0, *)
 extension DispatchSource {
-  /// Creates a new publisher for monitoring file-system events.
+  /// Creates a new publisher for monitoring file system events.
   /// - Parameters:
-  ///   - events: The set of events to monitor. For a list of possible values, see DispatchSource.FileSystemEvent.
+  ///   - events: The set of events to monitor.
   ///   - fd: A file descriptor pointing to an open file or socket.
-  /// - Returns: a publisher that triggers when events occur on the observed file
+  /// - Returns: A publisher that triggers when events occur at the observed file.
   public static func publish(_ events: FileSystemEvent = .all, at fd: FileDescriptor) -> AnyPublisher<FileSystemEvent, Never> {
     FileSystemEventPublisher(of: events, at: fd).eraseToAnyPublisher()
   }

--- a/Tests/FileSystemEventPublisherTests/FileSystemEventPublisherTests.swift
+++ b/Tests/FileSystemEventPublisherTests/FileSystemEventPublisherTests.swift
@@ -1,3 +1,4 @@
+import System
 import XCTest
 @testable import FileSystemEventPublisher
 
@@ -6,14 +7,31 @@ let File = FileManager.default.temporaryDirectory
 
 @available(macOS 11.0, *, iOS 14.0, *)
 final class FileSystemEventPublisherTests: XCTestCase {
-  func test() {
+  func testReceive() {
+    let tmp = FileManager.default.temporaryDirectory
+    let expectation = self.expectation(description: "receive")
+
+    var received = DispatchSource.FileSystemEvent()
+    XCTAssertEqual(received.rawValue, 0)
+
+    var fd = try! FileDescriptor.open(tmp.path, .readOnly, options: .eventOnly)
+    XCTAssertEqual(close(fd.rawValue), 0)
+
+    fd = try! FileDescriptor.open(tmp.path, .readOnly, options: .eventOnly)
+
     let cancellable = DispatchSource.publish(
       .all,
-      for: FileManager.default.temporaryDirectory
-    ).receive(on: RunLoop.main).sink { event in
-      print(event)
+      at: fd
+    ).sink { event in
+      received = event
+      expectation.fulfill()
     }
+
+    let url = URL(fileURLWithPath: "\(UUID())", relativeTo: tmp)
+    try! FileManager.default.createDirectory(at: url, withIntermediateDirectories: false, attributes: nil)
+
+    waitForExpectations(timeout: 0.1, handler: nil)
+    XCTAssertNotEqual(received.rawValue, 0)
     cancellable.cancel()
-    XCTAssertEqual(self, self)
   }
 }


### PR DESCRIPTION
Version 2.0:

- Added Xcode documentation;
- Changed file reference from URL to file descriptor, so we don't throw any exception. It is the client responsibility to pass a valid file descriptor pointing to an open file/directory.